### PR TITLE
Move key url param to hash param

### DIFF
--- a/cli/cli2cloud/cli2cloud.go
+++ b/cli/cli2cloud/cli2cloud.go
@@ -59,7 +59,7 @@ func sendPipedMessages(c proto.Cli2CloudClient, ctx context.Context, password *s
 
 	keyURLSuffix := ""
 	if password != nil {
-		keyURLSuffix = fmt.Sprintf("?key=%s", *password)
+		keyURLSuffix = fmt.Sprintf("#key=%s", *password)
 	}
 
 	fmt.Printf("Share and monitor it live from https://cli2cloud.com/%s%s\n\n", clientId.Id, keyURLSuffix)

--- a/cli/cli2cloud/cli2cloud.go
+++ b/cli/cli2cloud/cli2cloud.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	//serverIP             = "localhost:50051" // local dev
-	serverIP             = "167.99.140.19:50051" // production
+	serverIP = "localhost:50051" // local dev
+	//serverIP             = "cli2cloud.com:50051" // production
 	randomPasswordLength = 16
 )
 

--- a/cli/cli2cloud/cli2cloud.go
+++ b/cli/cli2cloud/cli2cloud.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	serverIP = "localhost:50051" // local dev
-	//serverIP             = "cli2cloud.com:50051" // production
+	//serverIP = "localhost:50051" // local dev
+	serverIP             = "cli2cloud.com:50051" // production
 	randomPasswordLength = 16
 )
 

--- a/webapp/src/pages/Monitor.tsx
+++ b/webapp/src/pages/Monitor.tsx
@@ -57,8 +57,8 @@ export class Monitor extends Component<{}, State> {
         };
 
         this.numLines = 1;
-        //this.cli2CloudService = new Cli2CloudClient("https://cli2cloud.com:1443", null, null); // production
-        this.cli2CloudService = new Cli2CloudClient("http://localhost:8000", null, null); // local dev
+        this.cli2CloudService = new Cli2CloudClient("https://cli2cloud.com:1443", null, null); // production
+        //this.cli2CloudService = new Cli2CloudClient("http://localhost:8000", null, null); // local dev
 
         this.clientId = new ClientId();
         const id = window.location.pathname.substring(1);

--- a/webapp/src/styles/Monitor.module.css
+++ b/webapp/src/styles/Monitor.module.css
@@ -19,12 +19,6 @@
     color: yellow;
 }
 
-.row:target {
-    background-color: yellow;
-    opacity: 0.8;
-    color: #000000
-}
-
 .selectedRow {
     background-color: yellow;
     opacity: 0.8;

--- a/webapp/src/styles/Monitor.module.css
+++ b/webapp/src/styles/Monitor.module.css
@@ -25,6 +25,14 @@
     color: #000000
 }
 
+.selectedRow {
+    background-color: yellow;
+    opacity: 0.8;
+    color: #000000;
+    display: flex;
+    clear: both;
+}
+
 .line {
     min-width: 5%;
     float: left;


### PR DESCRIPTION
Moves the `key=1234` URL parameter to the hash parameters since they do not get sent to the webservers.
Fixes [#10](https://github.com/leonwind/cli2cloud/issues/10#issue-1175278433).