### PR TITLE
Add .gitattributes

### DIFF
--- a/webapp/src/proto/.gitattributes
+++ b/webapp/src/proto/.gitattributes
@@ -1,0 +1,3 @@
+service_pb.d.ts linguist-documentation
+service_pb.js linguist-documentation
+ServiceServiceClientPb.ts linguist-documentation


### PR DESCRIPTION
Remove ts / js generated proto files from github language statistics.